### PR TITLE
Send guestbook API key in body

### DIFF
--- a/index.html
+++ b/index.html
@@ -537,6 +537,7 @@
         e.preventDefault();
         status.textContent = 'Se trimite...';
         const payload = {
+          apiKey: API_KEY,
           name: document.getElementById('gbName').value.trim(),
           message: document.getElementById('gbMessage').value.trim()
         };
@@ -544,8 +545,7 @@
           const res = await fetch(API_URL, {
             method: 'POST',
             headers: {
-              'Content-Type': 'application/json',
-              'X-Guestbook-Key': API_KEY
+              'Content-Type': 'text/plain'
             },
             body: JSON.stringify(payload)
           });


### PR DESCRIPTION
## Summary
- Update guestbook submission to send API key in request body and avoid custom headers.
- Post JSON as text/plain to match backend expectations.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899a48026bc832e948c1fba168d2c49