### PR TITLE
Remove upload note and reposition table notice

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,8 +161,6 @@
       </div>
     </figure>
 
-    <div class="note">Formularul permite <strong>încărcarea de fotografii sau video</strong>. Numărul mesei va fi disponibil și fizic, la locație.</div>
-
     <div class="actions">
       <a href="https://forms.gle/Ji3SCJTNThM8GApL7" target="_blank" class="action-btn">Încarcă foto/video</a>
       <a href="meniu.html" class="action-btn">Meniu</a>
@@ -191,6 +189,7 @@
     <div id="contactBox" class="reveal-box" hidden>Georgian: 0754706716 &nbsp;&bull;&nbsp; Diana: 0748436309</div>
 
     <input type="text" id="search" placeholder="Căutați masa după orice parte din nume (cu sau fără diacritice)..." autofocus autocomplete="off" />
+    <div class="note">Numărul mesei va fi disponibil și fizic, la locație.</div>
     <div class="count" id="count"></div>
     <div class="results" id="results"></div>
 


### PR DESCRIPTION
## Summary
- remove outdated note about photo/video uploads
- show table number availability below the search field

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899aa0263d4832e8fc2398b15289995