### PR TITLE
Move table number note above search box

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,8 +188,8 @@
 
     <div id="contactBox" class="reveal-box" hidden>Georgian: 0754706716 &nbsp;&bull;&nbsp; Diana: 0748436309</div>
 
-    <input type="text" id="search" placeholder="Căutați masa după orice parte din nume (cu sau fără diacritice)..." autofocus autocomplete="off" />
     <div class="note">Numărul mesei va fi disponibil și fizic, la locație.</div>
+    <input type="text" id="search" placeholder="Căutați masa după orice parte din nume (cu sau fără diacritice)..." autofocus autocomplete="off" />
     <div class="count" id="count"></div>
     <div class="results" id="results"></div>
 


### PR DESCRIPTION
## Summary
- Reordered informational note so table number message appears above the search input for guests.

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden accessing npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_689c3d868adc832eacb0331ce8ec9e7d